### PR TITLE
telegram-text integration

### DIFF
--- a/origamibot/core/bot.py
+++ b/origamibot/core/bot.py
@@ -2,7 +2,7 @@ from origamibot.core.teletypes.command_scope import BotCommandScope
 import shlex
 import logging
 
-from typing import List, Optional, Union, IO, Callable
+from typing import List, Optional, Union, IO, Callable, Literal
 from collections import deque
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import current_thread, Event
@@ -90,6 +90,11 @@ from .api_request import (
     )
 
 from ..listener import Listener
+
+try:
+  from telegram_text.bases import Element
+except ImportError:
+  class Element: ...  # fallback for type hints
 
 
 using_greenlets = False
@@ -323,8 +328,8 @@ class OrigamiBot:
 
     def send_message(self,
                      chat_id: Union[int, str],
-                     text: str,
-                     parse_mode: Optional[str] = None,
+                     text: Union[str, Element],
+                     parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                      disable_web_page_preview: Optional[bool] = None,
                      disable_notification: Optional[bool] = None,
                      reply_to_message_id: Optional[int] = None,
@@ -347,8 +352,8 @@ class OrigamiBot:
 
     def reply_to(self, 
                  msg: Message,
-                 text: str, 
-                 parse_mode: Optional[str] = None,
+                 text: Union[str, Element], 
+                 parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                  disable_web_page_preview: Optional[bool] = None,
                  disable_notification: Optional[bool] = None,
                  reply_markup: Optional[ReplyMarkup] = None,
@@ -389,8 +394,8 @@ class OrigamiBot:
     def send_photo(self,
                    chat_id: Union[int, str],
                    photo: Union[str, IO],
-                   caption: Optional[str] = None,
-                   parse_mode: Optional[str] = None,
+                   caption: Union[str, Element, None] = None,
+                   parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                    disable_notification: Optional[bool] = None,
                    reply_to_message_id: Optional[int] = None,
                    reply_markup: Optional[ReplyMarkup] = None,
@@ -415,8 +420,8 @@ class OrigamiBot:
     def send_audio(self,
                    chat_id: Union[int, str],
                    audio: Union[str, IO],
-                   caption: Optional[str] = None,
-                   parse_mode: Optional[str] = None,
+                   caption: Union[str, Element, None] = None,
+                   parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                    duration: Optional[int] = None,
                    performer: Optional[str] = None,
                    title: Optional[str] = None,
@@ -451,8 +456,8 @@ class OrigamiBot:
                       chat_id: Union[int, str],
                       document: Union[str, IO],
                       thumb: Optional[Union[str, IO]] = None,
-                      caption: Optional[str] = None,
-                      parse_mode: Optional[str] = None,
+                      caption: Union[str, Element, None] = None,
+                      parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                       disable_notification: Optional[bool] = None,
                       reply_to_message_id: Optional[int] = None,
                       reply_markup: Optional[ReplyMarkup] = None,
@@ -482,8 +487,8 @@ class OrigamiBot:
                    width: Optional[int] = None,
                    height: Optional[int] = None,
                    thumb: Optional[Union[str, IO]] = None,
-                   caption: Optional[str] = None,
-                   parse_mode: Optional[str] = None,
+                   caption: Union[str, Element, None] = None,
+                   parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                    supports_streaming: Optional[bool] = None,
                    disable_notification: Optional[bool] = None,
                    reply_to_message_id: Optional[int] = None,
@@ -521,7 +526,7 @@ class OrigamiBot:
                        height: Optional[int] = None,
                        thumb: Optional[Union[str, IO]] = None,
                        caption: Optional[Union[str, IO]] = None,
-                       parse_mode: Optional[str] = None,
+                       parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                        disable_notification: Optional[bool] = None,
                        reply_to_message_id: Optional[int] = None,
                        reply_markup: Optional[ReplyMarkup] = None,
@@ -550,8 +555,8 @@ class OrigamiBot:
     def send_voice(self,
                    chat_id: Union[int, str],
                    voice: Union[str, IO],
-                   caption: Optional[str] = None,
-                   parse_mode: Optional[str] = None,
+                   caption: Union[str, Element, None] = None,
+                   parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                    duration: Optional[int] = None,
                    disable_notification: Optional[bool] = None,
                    reply_to_message_id: Optional[int] = None,
@@ -750,7 +755,7 @@ class OrigamiBot:
                   allows_multiple_answers: Optional[bool] = None,
                   correct_option_id: Optional[int] = None,
                   explanation: Optional[str] = None,
-                  explanation_parse_mode: Optional[str] = None,
+                  explanation_parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                   open_period: Optional[int] = None,
                   close_date: Optional[int] = None,
                   is_closed: Optional[bool] = None,
@@ -1286,10 +1291,10 @@ class OrigamiBot:
 
     def edit_message_text(self,
                           chat_id: Union[int, str],
-                          text: str,
+                          text: Union[str, Element],
                           message_id: Optional[int] = None,
                           inline_message_id: Optional[str] = None,
-                          parse_mode: Optional[str] = None,
+                          parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                           disable_web_page_preview: Optional[bool] = None,
                           reply_markup: Optional[InlineKeyboardMarkup] = None
                           ) -> Union[Message, bool]:
@@ -1312,10 +1317,10 @@ class OrigamiBot:
 
     def edit_message_caption(self,
                              chat_id: Union[int, str],
-                             caption: Optional[str] = None,
+                             caption: Union[str, Element, None] = None,
                              message_id: Optional[int] = None,
                              inline_message_id: Optional[str] = None,
-                             parse_mode: Optional[str] = None,
+                             parse_mode: Optional[Literal["HTML", "MarkdownV2", "Markdown"]] = None,
                              reply_markup: Optional[
                                  InlineKeyboardMarkup] = None
                              ) -> Union[Message, bool]:

--- a/origamibot/text.py
+++ b/origamibot/text.py
@@ -1,0 +1,4 @@
+try:
+  from telegram_text import *
+except ImportError:
+  pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "atomicwrites"
-version = "1.4.0"
+version = "1.4.1"
 description = "Atomic file writes."
 category = "dev"
 optional = false
@@ -8,21 +8,21 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.4.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -30,7 +30,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.1.0"
+version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -49,7 +49,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -188,6 +188,14 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "telegram-text"
+version = "0.1.0"
+description = "Python markup module for Telegram messenger. This module provides a rich list of components to build any possible markup fast and render it to specific html or MarkdownV2 formats."
+category = "main"
+optional = true
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -205,59 +213,47 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.9"
+version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "zipp"
-version = "3.8.0"
+version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+
+[extras]
+telegram-text = ["telegram-text"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "59d2e244067e2de11542d2d28a5e03b580092357277bf153c9e66bb7632aa862"
+content-hash = "02b30bc7f1dc9136a3fadfa92946c0484bf5fa0533199f84f2b458421e0ede4b"
 
 [metadata.files]
-atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
-]
-attrs = [
-    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
-    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
-]
-certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
-]
-charset-normalizer = [
-    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
-    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
-]
+atomicwrites = []
+attrs = []
+certifi = []
+charset-normalizer = []
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
-idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
-]
+idna = []
 importlib-metadata = [
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
     {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
@@ -299,6 +295,7 @@ requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
+telegram-text = []
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
@@ -307,11 +304,5 @@ typing-extensions = [
     {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
     {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
-urllib3 = [
-    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
-    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
-]
-zipp = [
-    {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},
-    {file = "zipp-3.8.0.tar.gz", hash = "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"},
-]
+urllib3 = []
+zipp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,15 @@ readme = 'README.md'
 [tool.poetry.dependencies]
 python = "^3.7"
 requests = "^2.25.1"
+telegram-text = { version = "^0.1.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"
 python-dotenv = "^0.18.0"
 pytest-ordering = "^0.6"
+
+[tool.poetry.extras]
+telegram-text = ["telegram-text"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "origamibot"
-version = "2.2.2"
+version = "2.3.0"
 description = "Library for creating bots for telegram with Python."
 authors = ["Crystal Melting Dot <stresspassing@gmail.com>"]
 license = "MIT"

--- a/tests/test_send_message.py
+++ b/tests/test_send_message.py
@@ -1,6 +1,18 @@
+from pytest import skip
 from . import bot, token, private_cid
+
+try:
+  from telegram_text import Bold
+  tg_text_present = True
+except ImportError:
+  tg_text_present = False
 
 
 def test_send_message(bot, private_cid):
     message = bot.send_message(chat_id=private_cid, text='Test message')
     assert message
+
+
+def test_telegram_text(bot, private_cid):
+  if not tg_text_present: skip("telegram_text is not installed")
+  message = bot.send_message(chat_id=private_cid, text=Bold("Bold text message"))


### PR DESCRIPTION
This pull request implements a simple [telegram-text](https://github.com/SKY-ALIN/telegram-text) integration, thus closes #26.

## How it works
- telegram-text is now an optional dependency, installation can be done with `pip install origamibot[telegram-text]` for example, or as a separate module of course.
- instances of `telegram_text.base.Element` and it's descendants can be passed straight to `text` and `caption` parameters of API calls.
- Appropriate type hints are in place
- when converting to markup string, takes into account passed `parse_mode`, if not present sets it to `HTML` by default.
- old-style text messages are unaffected
- if telegram-text is not installed converting function is no-op

## Example usage
```python
from origamibot import OrigamiBot
from telegram_text import Bold

token: str = "blahblah"
my_cid: int = 12516745
bot = OrigamiBot(token)
bot.send_message(my_cid, Bold("Bold text message"))
```