### PR TITLE
Fix tg rate limit updates crash

### DIFF
--- a/origamibot/core/bot.py
+++ b/origamibot/core/bot.py
@@ -9,6 +9,7 @@ from threading import current_thread, Event
 from time import sleep
 
 from .sthread import StoppableThread
+from .exceptions import TelegramAPIError
 from .teletypes import (
     Update,
     Message,
@@ -1438,10 +1439,10 @@ class OrigamiBot:
             if self.safe_poll:
                 try:
                     updates = self.get_updates()
-                except (IOError, ConnectionError) as err:
+                except (IOError, ConnectionError, TelegramAPIError) as err:
                     logger.exception('Exception while polling')
                     self._call_listeners('on_poll_error', err)
-                    sleep(2)
+                    sleep(5)
                     continue
             else:
                 updates = self.get_updates()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "origamibot"
-version = "2.3.2"
+version = "2.3.3"
 description = "Library for creating bots for telegram with Python."
 authors = ["Crystal Melting Dot <stresspassing@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Added TelegramAPIError to except clause to ignore it's `429 Too many requests` error, should fix #30 