### PR TITLE
Add file validation for send_media_group

### DIFF
--- a/origamibot/core/api_request.py
+++ b/origamibot/core/api_request.py
@@ -1571,10 +1571,11 @@ def send_media_group(token: str,
 
     files = dict()
     for media_item in media:
-        attach_name, file_path = media_item.file
-        if not all([attach_name, file_path]):
-            continue
-        files[attach_name] = file_path
+        if hasattr(media_item, 'file') and media_item.file and isinstance(media_item.file.value, tuple):
+            attach_name, file_path = media_item.file
+            if not all([attach_name, file_path]):
+                continue
+            files[attach_name] = file_path
 
     return request(
         token,


### PR DESCRIPTION
So.. When I tried to send `InputMediaPhoto` using `send_media_group` function it gave me this error:
![image](https://github.com/user-attachments/assets/6685d604-4d03-4989-b9fd-7dcad5644a0a)

I think there should be a check if the attribute is in the class because I don't see it in `InputMediaPhoto`, `InputMedia` and `TelegramStructure`